### PR TITLE
Fix homepage horizontal scroll / right-side whitespace

### DIFF
--- a/components/main-page/MainHeader.module.css
+++ b/components/main-page/MainHeader.module.css
@@ -21,6 +21,24 @@
   }
 }
 
+/*
+ * Product Hunt badge. The badge has a fixed natural size (238x49), but its
+ * column is only ~2/3 of the viewport on phones, where a hard 238px width
+ * overflowed the right edge and caused horizontal scroll. Cap the width to the
+ * column and let the aspect ratio scale the height so it always fits.
+ */
+.productHuntBadge {
+  display: inline-block;
+  width: 238px;
+  max-width: 100%;
+  aspect-ratio: 238 / 49;
+  margin-top: 10px;
+  line-height: 0;
+  background: url('https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=279660&theme=light&period=daily')
+    no-repeat center center;
+  background-size: contain;
+}
+
 .pageNavigation {
   display: inline-block;
 }

--- a/components/main-page/MainHeader.tsx
+++ b/components/main-page/MainHeader.tsx
@@ -52,15 +52,7 @@ export default function MainHeader() {
             <div className="align-right">
               <a
                 href="https://www.producthunt.com/posts/tabbied?utm_source=badge-top-post-badge&utm_medium=badge&utm_souce=badge-tabbied"
-                style={{
-                  background:
-                    'url("https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=279660&theme=light&period=daily") no-repeat center center',
-                  display: 'inline-block',
-                  width: '238px',
-                  height: '49px',
-                  lineHeight: 0,
-                  marginTop: '10px',
-                }}
+                className={styles.productHuntBadge}
                 target="_blank"
                 rel="noreferrer"
                 aria-label="Tabbied on Product Hunt"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -106,6 +106,18 @@ th:not([align]) {
   --red-high-contrast: #ed005f;
 }
 
+/*
+ * Guard against accidental horizontal scroll (and the right-side whitespace
+ * it produces) on every page. A stray fixed-width or full-bleed element that
+ * pokes past the viewport should be clipped rather than widen the document.
+ * No sticky positioning is used anywhere, so clipping here is side-effect free.
+ */
+html,
+body {
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
 body {
   color: var(--gray-medium);
   font-family: var(--font-sans-serif);


### PR DESCRIPTION
## Problem

On mobile, the homepage scrolls horizontally and shows empty whitespace to the right of the content (see reported screenshot).

## Root cause

The Product Hunt badge in the main header (`components/main-page/MainHeader.tsx`) had a hard-coded `width: 238px`. It lives in a `Col xs={8}` column, which is only ~⅔ of the viewport on phones (~208px on a 360px-wide screen). The 238px badge poked ~30px past the right edge, widening the document and producing the horizontal scroll + whitespace.

## Fix

- **Root cause:** Moved the badge's inline styles into `MainHeader.module.css` as `.productHuntBadge` and capped its width to the column with `max-width: 100%` + `aspect-ratio: 238 / 49` and `background-size: contain`, so it scales down to fit instead of overflowing.
- **Defense in depth (all pages):** Added an `html, body { max-width: 100%; overflow-x: hidden; }` guard in `styles/globals.css` so any stray full-bleed or fixed-width element can never widen the document on any page. No `position: sticky` is used anywhere in the app, so this clipping is side-effect free.

## Verification

`yarn build` passes. Measured `documentElement.scrollWidth` vs `clientWidth` at a 360px viewport with Playwright across `/`, `/select-artwork/`, and `/artwork/blossom/` — **no overflow on any page** (scrollWidth == clientWidth == 360). Independently confirmed the badge's right edge is now at 344px (≤ 360px), so the element genuinely fits rather than being clipped by the guard.

https://claude.ai/code/session_01FvNJuh7bRcfntLN1fWFhoD

---
_Generated by [Claude Code](https://claude.ai/code/session_01FvNJuh7bRcfntLN1fWFhoD)_