### PR TITLE
Skip Vercel builds for agent-outputs-only changes

### DIFF
--- a/scripts/vercel-ignore-build.sh
+++ b/scripts/vercel-ignore-build.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Vercel "Ignored Build Step" — skip deployments that only touch agent-outputs/.
+#
+# Wired up via the repo's vercel.json:
+#   { "ignoreCommand": "bash scripts/vercel-ignore-build.sh" }
+# (ignoreCommand overrides the dashboard "Ignored Build Step", so no UI step is
+# needed. The same command also works if pasted into that dashboard setting.)
+#
+# Exit-code contract defined by Vercel:
+#   exit 1 → continue the build / create a deployment
+#   exit 0 → cancel the build (no deployment)
+#
+# Rule: build whenever anything OUTSIDE agent-outputs/ changed in this push;
+# otherwise skip. If the commit range can't be determined we err on the side
+# of building so a real change is never silently dropped.
+
+set -uo pipefail
+
+# Path(s) that should not, on their own, trigger a deployment.
+EXCLUDE_PATHSPEC=':(exclude)agent-outputs/'
+
+head_sha="${VERCEL_GIT_COMMIT_SHA:-HEAD}"
+base_sha="${VERCEL_GIT_PREVIOUS_SHA:-}"
+
+# Fall back to the parent commit when Vercel doesn't give us a usable previous
+# SHA (empty, or absent from this shallow clone — e.g. the first deploy).
+if [ -z "$base_sha" ] || ! git rev-parse --verify --quiet "${base_sha}^{commit}" >/dev/null 2>&1; then
+  if git rev-parse --verify --quiet "${head_sha}^" >/dev/null 2>&1; then
+    base_sha="${head_sha}^"
+  else
+    echo "vercel-ignore-build: no diff range available — proceeding with the build."
+    exit 1
+  fi
+fi
+
+if git diff --quiet "$base_sha" "$head_sha" -- . "$EXCLUDE_PATHSPEC"; then
+  echo "vercel-ignore-build: only agent-outputs/ changed (${base_sha}..${head_sha}) — skipping build."
+  exit 0
+fi
+
+echo "vercel-ignore-build: changes outside agent-outputs/ detected — proceeding with the build."
+exit 1

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "bash scripts/vercel-ignore-build.sh"
+}


### PR DESCRIPTION
## What & why

Adds a Vercel **Ignored Build Step** so that pushes which only touch `agent-outputs/` (e.g. generated markdown reports) do **not** trigger a deployment, while any change elsewhere builds as normal. This lets us commit generated reports without burning a build job on content that doesn't affect the site.

## Changes (this PR's tip commit)

- **`vercel.json`** — wires up the ignore command:
  ```json
  {
    "$schema": "https://openapi.vercel.sh/vercel.json",
    "ignoreCommand": "bash scripts/vercel-ignore-build.sh"
  }
  ```
- **`scripts/vercel-ignore-build.sh`** (executable) — diffs the push range with `git diff --quiet "$base" "$head" -- . ':(exclude)agent-outputs/'` and follows Vercel's exit-code contract: `exit 0` cancels the build, `exit 1` continues it.

## Behavior

- Only `agent-outputs/` changed → **skip** deployment (`exit 0`).
- Anything outside `agent-outputs/` changed (including mixed pushes) → **build** (`exit 1`).
- `VERCEL_GIT_PREVIOUS_SHA` empty/unreachable (shallow clone, first deploy) → falls back to `HEAD^`, and if even that's unavailable, **builds** — so a real change is never silently dropped.

## Verification

Ran the script locally across five scenarios on a throwaway branch; all matched expectations:

| Scenario | Change | Result |
|----------|--------|--------|
| agent-outputs only | `agent-outputs/report.md` | skip (exit 0) ✓ |
| real source file | `README.md` | build (exit 1) ✓ |
| mixed | both | build (exit 1) ✓ |
| empty base → `HEAD^` (mixed) | both | build (exit 1) ✓ |
| unreachable base → `HEAD^` (agent-outputs only) | report.md | skip (exit 0) ✓ |

> Note: this branch is 11 commits ahead of `main`; the tip commit is the Vercel change above, and the preceding 10 commits are pre-existing unmerged branch work (Next.js App Router migration & editor changes).

https://claude.ai/code/session_01Hi7He6gn3s3vTS6dfMJsL5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hi7He6gn3s3vTS6dfMJsL5)_