### PR TITLE
Render gallery thumbnails as live css-doodle

### DIFF
--- a/components/edit-artwork-page/EditArtwork.tsx
+++ b/components/edit-artwork-page/EditArtwork.tsx
@@ -21,6 +21,7 @@ import EditArtworkHeader from 'components/edit-artwork-page/EditArtworkHeader';
 import ButtonSelectGroup from 'components/ButtonSelectGroup';
 import ValueSlider from 'components/ValueSlider';
 import ToggleSwitch from 'components/ToggleSwitch';
+import { buildDoodleSource, type OptionValue } from 'lib/doodleSource';
 import styles from './EditArtwork.module.css';
 
 const Doodle = dynamic(() => import('components/Doodle'), {
@@ -30,8 +31,6 @@ const Doodle = dynamic(() => import('components/Doodle'), {
 const ColorPicker = dynamic(() => import('components/ColorPicker'), {
   ssr: false,
 });
-
-type OptionValue = string | number | boolean;
 
 // Options with this id hold a "colsxrows" grid string and follow the selected
 // aspect ratio so that cells stay (near-)square.
@@ -142,14 +141,6 @@ const getExpandIconColor = (background: string): string => {
 
 const arraysEqual = (a: string[], b: string[]) =>
   a.length === b.length && a.every((value, index) => value === b[index]);
-
-// css-doodle >= 0.5 reads `@random(1)` as a one-cell count rather than a 100%
-// probability gate (fractional values still behave as probabilities). The
-// artwork definitions were authored against css-doodle 0.12 where `@random(1)`
-// meant "every cell", so nudge the fully-on case just under 1 to preserve the
-// original look at maximum frequency.
-const fixFullRandomGate = (code: string) =>
-  code.replace(/@random\s*\(\s*1(?:\.0+)?\s*\)/g, '@random(0.999)');
 
 export default function EditArtwork({ artwork }: { artwork: Artwork }) {
   // A preset may pin itself to a single aspect ratio (e.g. Symmetry), in which
@@ -356,60 +347,21 @@ export default function EditArtwork({ artwork }: { artwork: Artwork }) {
     });
   };
 
-  const getColorsStyleCode = (colors: string[]) =>
-    colors.map((color, idx) => `--color${idx}: ${color};\n`).join('');
-
   // Build the css-doodle source for a given canvas size. The pattern depends
   // only on the seed and grid, so the same seed produces the same artwork at
   // any size — letting the expanded dialog render a larger copy that matches.
-  const buildDoodleSource = (canvasWidth: number, canvasHeight: number) => {
-    let newStyleCode = artwork.code.style;
-    let newDoodleCode = artwork.code.doodle;
-
-    artwork.options.forEach((option, index) => {
-      switch (option.type) {
-        case 'ButtonSelectGroup':
-        case 'Slider':
-          newStyleCode = newStyleCode
-            .split(option.replace)
-            .join(String(optionValues[index]));
-
-          newDoodleCode = newDoodleCode
-            .split(option.replace)
-            .join(String(optionValues[index]));
-
-          break;
-        case 'ToggleSwitch':
-          if (optionValues[index]) {
-            newStyleCode = newStyleCode
-              .split(option.replace)
-              .join(option.code ?? '');
-            newDoodleCode = newDoodleCode
-              .split(option.replace)
-              .join(String(optionValues[index]));
-          } else {
-            newStyleCode = newStyleCode.split(option.replace).join('');
-            newDoodleCode = newDoodleCode.split(option.replace).join('');
-          }
-          break;
-        default:
-          break;
-      }
+  const buildSource = (canvasWidth: number, canvasHeight: number) =>
+    buildDoodleSource({
+      code: artwork.code,
+      options: artwork.options,
+      palette,
+      optionValues,
+      width: `${canvasWidth}px`,
+      height: `${canvasHeight}px`,
     });
 
-    newDoodleCode = newDoodleCode.split('${width}').join(`${canvasWidth}px`);
-    newDoodleCode = newDoodleCode.split('${height}').join(`${canvasHeight}px`);
-
-    newStyleCode = fixFullRandomGate(newStyleCode);
-    newDoodleCode = fixFullRandomGate(newDoodleCode);
-
-    newStyleCode = getColorsStyleCode(palette) + newStyleCode;
-
-    return { styleCode: newStyleCode, doodleCode: newDoodleCode };
-  };
-
   const updateDoodleCode = () => {
-    const source = buildDoodleSource(width, height);
+    const source = buildSource(width, height);
 
     setStyleCode(source.styleCode);
     setDoodleCode(source.doodleCode);
@@ -487,7 +439,7 @@ export default function EditArtwork({ artwork }: { artwork: Artwork }) {
     (viewport?.height ?? 800) * 0.9
   );
   const expandedSource = isExpanded
-    ? buildDoodleSource(expanded.width, expanded.height)
+    ? buildSource(expanded.width, expanded.height)
     : null;
 
   return (

--- a/components/main-page/BrowseArtwork.tsx
+++ b/components/main-page/BrowseArtwork.tsx
@@ -1,19 +1,17 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { Container, Row, Col } from 'components/layout';
+import { getGalleryItems } from 'lib/artwork';
+import GalleryDoodle from 'components/select-artwork-page/GalleryDoodle';
 import styles from './BrowseArtwork.module.css';
 
-const gallery = [
-  { slug: 'radius', name: 'Radius', thumb: 'thumb_radius', white: true },
-  { slug: 'mixtape', name: 'Mixtape', thumb: 'thumb_mixtape' },
-  { slug: 'odessa', name: 'Odessa', thumb: 'thumb_odessa', white: true },
-  { slug: 'symmetry', name: 'Symmetry', thumb: 'thumb_symmetry' },
-  { slug: 'veil', name: 'Veil', thumb: 'thumb_veil' },
-  { slug: 'blossom', name: 'Blossom', thumb: 'thumb_blossom', white: true },
-  { slug: 'disque', name: 'Disque', thumb: 'thumb_disque' },
-];
+// The homepage shows the first handful of designs (galleryOrder 1–7); the full
+// set lives behind the "View All" card on the select-artwork page.
+const BROWSE_COUNT = 7;
 
-export default function BrowseArtworkSection() {
+export default async function BrowseArtworkSection() {
+  const gallery = (await getGalleryItems()).slice(0, BROWSE_COUNT);
+
   return (
     <div id="section-browse-artwork" className={styles.browseArtworkSection}>
       <Container>
@@ -34,12 +32,7 @@ export default function BrowseArtworkSection() {
                   <h4 className={item.white ? styles.white : undefined}>
                     {item.name}
                   </h4>
-                  <Image
-                    src={`/images/${item.thumb}.png`}
-                    alt={item.name}
-                    width={800}
-                    height={800}
-                  />
+                  <GalleryDoodle item={item} />
                 </div>
               </Link>
             </Col>

--- a/components/select-artwork-page/GalleryDoodle.tsx
+++ b/components/select-artwork-page/GalleryDoodle.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import type { GalleryItem } from 'lib/artwork';
+import styles from './SelectArtwork.module.css';
+
+// css-doodle registers a browser custom element on import, so the renderer can
+// only run on the client. The square frame is rendered here (outside the lazy
+// boundary) so the card reserves its space and nothing shifts when the doodle
+// mounts.
+const GalleryDoodleInner = dynamic(() => import('./GalleryDoodleInner'), {
+  ssr: false,
+});
+
+export default function GalleryDoodle({ item }: { item: GalleryItem }) {
+  return (
+    <div className={styles.doodleThumb}>
+      <GalleryDoodleInner item={item} />
+    </div>
+  );
+}

--- a/components/select-artwork-page/GalleryDoodleInner.tsx
+++ b/components/select-artwork-page/GalleryDoodleInner.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import 'css-doodle';
+import type { GalleryItem } from 'lib/artwork';
+import { buildDoodleSource } from 'lib/doodleSource';
+import { galleryThumbnails } from './galleryThumbnails';
+import styles from './SelectArtwork.module.css';
+
+const DEFAULT_RENDER = { width: 800, height: 800, cropTop: 1 };
+
+export default function GalleryDoodleInner({ item }: { item: GalleryItem }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const doodleRef = useRef<any>(null);
+  const [width, setWidth] = useState(0);
+
+  const config = galleryThumbnails[item.slug];
+  const render = { ...DEFAULT_RENDER, ...(config?.render ?? {}) };
+  const palette = config?.palette ?? item.palette;
+  const optionValues = item.options.map(
+    (option) => config?.options?.[option.id] ?? option.default
+  );
+
+  const { styleCode, doodleCode } = buildDoodleSource({
+    code: item.code,
+    options: item.options,
+    palette,
+    optionValues,
+    width: `${render.width}px`,
+    height: `${render.height}px`,
+  });
+
+  const seed = config?.seed ?? '0000';
+  const name = `thumb-${item.slug}`;
+
+  // Measure the square card so the fixed-resolution doodle can be scaled to fit.
+  useLayoutEffect(() => {
+    const element = containerRef.current;
+    if (!element) return;
+
+    const observer = new ResizeObserver((entries) => {
+      setWidth(Math.round(entries[0].contentRect.width));
+    });
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, []);
+
+  // css-doodle >= 0.5 no longer re-reads text content on a bare update(), so
+  // push the current source whenever it changes.
+  useEffect(() => {
+    doodleRef.current?.update?.(doodleCode);
+  }, [doodleCode]);
+
+  // Cover-fit the (possibly cropped) render into the square card. Scaling the
+  // whole element — rather than rendering at the card's pixel size — preserves
+  // the original 800px proportions of fixed-px strokes and shadows.
+  const visibleHeight = render.height * (render.cropTop ?? 1);
+  const scale = width
+    ? Math.max(width / render.width, width / visibleHeight)
+    : 0;
+  const translateX = (width - render.width * scale) / 2;
+
+  return (
+    <div ref={containerRef} className={styles.doodleThumbInner}>
+      <style>{`css-doodle#${name} { ${styleCode} }`}</style>
+      <css-doodle
+        id={name}
+        seed={seed}
+        use="var(--rule)"
+        ref={doodleRef}
+        style={{
+          width: `${render.width}px`,
+          height: `${render.height}px`,
+          transformOrigin: 'top left',
+          transform: `translateX(${translateX}px) scale(${scale})`,
+          // Hide the unscaled 800px element until it has been measured.
+          visibility: scale ? 'visible' : 'hidden',
+        }}
+      >
+        {doodleCode}
+      </css-doodle>
+    </div>
+  );
+}

--- a/components/select-artwork-page/SelectArtwork.module.css
+++ b/components/select-artwork-page/SelectArtwork.module.css
@@ -23,6 +23,27 @@
   color: white;
 }
 
+/* Live css-doodle thumbnail: a square frame that clips the scaled artwork. */
+.doodleThumb {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  overflow: hidden;
+  line-height: 0;
+}
+
+.doodleThumbInner {
+  position: absolute;
+  inset: 0;
+}
+
+.doodleThumbInner css-doodle {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: block;
+}
+
 /* Select-artwork page */
 .selectArtworkSection .grayBackground {
   background: rgba(248, 249, 250, 0.6);

--- a/components/select-artwork-page/SelectArtwork.tsx
+++ b/components/select-artwork-page/SelectArtwork.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
-import Image from 'next/image';
 import { Container, Row, Col } from 'components/layout';
 import type { GalleryItem } from 'lib/artwork';
+import GalleryDoodle from './GalleryDoodle';
 import styles from './SelectArtwork.module.css';
 
 export default function SelectArtwork({
@@ -29,12 +29,7 @@ export default function SelectArtwork({
                     <h4 className={item.white ? styles.white : undefined}>
                       {item.name}
                     </h4>
-                    <Image
-                      src={`/images/thumb_${item.slug}.png`}
-                      alt={item.name}
-                      width={800}
-                      height={800}
-                    />
+                    <GalleryDoodle item={item} />
                   </div>
                 </Link>
               </Col>

--- a/components/select-artwork-page/galleryThumbnails.ts
+++ b/components/select-artwork-page/galleryThumbnails.ts
@@ -1,0 +1,87 @@
+// Per-artwork settings used to reproduce the original raster gallery thumbnails
+// (public/images/thumb_*.png) as live css-doodle. Palettes and densities were
+// derived from the source images; `color0` is always the background. Because
+// css-doodle is seeded-random the exact placement can't be reproduced, so a
+// fixed seed that lands "close enough" to the original is pinned per design.
+import type { OptionValue } from 'lib/doodleSource';
+
+export type ThumbnailConfig = {
+  /** Palette override (color0 = background). Falls back to the artwork palette. */
+  palette?: string[];
+  /** Option overrides keyed by option id (grid / frequency / toggles). */
+  options?: Record<string, OptionValue>;
+  /** Fixed seed so each thumbnail is deterministic. */
+  seed: string;
+  /**
+   * Internal render size in px. The doodle is drawn at this resolution and then
+   * scaled to fit the (square) card, so fixed-px features (border widths,
+   * shadows) keep the proportions of the original 800px artwork. Defaults to
+   * 800 x 800. `cropTop` keeps only the top fraction of the render (Symmetry
+   * shows just its top half).
+   */
+  render?: { width: number; height: number; cropTop?: number };
+};
+
+export const galleryThumbnails: Record<string, ThumbnailConfig> = {
+  radius: {
+    palette: ['#3E8BFF', '#3B3F45', '#3FFFB2', '#3EECFF', '#97F4FF', '#FF3D8B'],
+    options: { grid: '4x4', frequency: 0.42 },
+    seed: 'radius7',
+  },
+  mixtape: {
+    palette: ['#80FBB8', '#232529', '#4D8CF7', '#4D8CF7', '#3E8BFF', '#232529'],
+    options: { grid: '3x3', frequency: 0.34 },
+    seed: 'mxA',
+  },
+  odessa: {
+    palette: ['#1B4075', '#3EECFF', '#D89FFF', '#3E8BFF', '#3FFFB2'],
+    options: { grid: '4x4', frequency: 0.6 },
+    seed: 'odessa5',
+  },
+  symmetry: {
+    palette: ['#97F4FF', '#97F4FF', '#00FFF3', '#00A1FF', '#FF8DFF', '#FF007E'],
+    options: { circularity: 1 },
+    render: { width: 800, height: 1200, cropTop: 0.5 },
+    seed: 'symm2',
+  },
+  veil: {
+    palette: ['#9EFFD8', '#3E8BFF', '#326DC9', '#1B4075', '#3EECFF', '#3E8BFF'],
+    options: { grid: '8x8', frequency: 0.42 },
+    seed: 'veil4',
+  },
+  blossom: {
+    palette: ['#367DE6', '#3EECFF', '#3FFFB2', '#FF3D8B', '#3FFFB2', '#FF3D8B'],
+    options: { grid: '3x3', frequency: 0.6 },
+    seed: 'blossom6',
+  },
+  disque: {
+    palette: ['#3EECFF', '#232529', '#1B4075', '#FF3D8B', '#E9F1FF', '#367DE6'],
+    options: { grid: '4x4', frequency: 0.55 },
+    seed: 'disque8',
+  },
+  bloks: {
+    palette: ['#3FFFB2', '#ECFFEC', '#9EFFD8', '#ECFFEC', '#9EFFD8', '#FFFFFF'],
+    options: { grid: '3x3', frequency: 1, shadow: true },
+    seed: 'bloks1',
+  },
+  terrain: {
+    palette: ['#232529', '#3E434B', '#3E8BFF', '#3FFFB2', '#275AA6', '#3EECFF'],
+    options: { grid: '4x4', frequency: 0.85 },
+    // Shape size is a fixed px formula (÷ column count); rendering smaller makes
+    // the shapes read large against the card, matching the bold original.
+    render: { width: 360, height: 360 },
+    seed: 'terrain9',
+  },
+  trigram: {
+    palette: ['#275AA6', '#3E8BFF', '#3EECFF', '#97F4FF', '#FFFFFF'],
+    options: { grid: '4x4', frequency: 0.5, roundedCorners: true },
+    seed: 'trigram4',
+  },
+  ring: {
+    // Muted maroon rings (color1/color2) over the dark, semi-transparent
+    // crescent (color3) — matching the soft, tonal rings of the original.
+    palette: ['#FF3D8B', '#C9447A', '#A33261', '#232529'],
+    options: { grid: '3x3', frequency: 0.75 },
+    seed: 'ringB',
+  },
+};

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -45,6 +45,37 @@ test.describe('Tabbied site', () => {
     ).toBeVisible({ timeout: 15000 });
   });
 
+  test('select-artwork gallery renders live css-doodle thumbnails', async ({
+    page,
+  }) => {
+    await page.goto('/select-artwork');
+
+    // The raster <img> thumbnails were replaced by per-design css-doodle, so a
+    // thumbnail element must mount and actually paint cells (guards against the
+    // ssr:false boundary / source-building regressing to an empty grid).
+    await page.waitForFunction(() => !!window.customElements.get('css-doodle'));
+    await expect(page.locator('css-doodle#thumb-radius')).toBeAttached({
+      timeout: 15000,
+    });
+
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const el = document.querySelector('css-doodle#thumb-radius');
+            if (!el || !el.shadowRoot) return 0;
+            return [...el.shadowRoot.querySelectorAll('cssd-cell')].filter(
+              (cell) => {
+                const bg = getComputedStyle(cell).backgroundColor;
+                return bg && bg !== 'rgba(0, 0, 0, 0)';
+              }
+            ).length;
+          }),
+        { timeout: 10000 }
+      )
+      .toBeGreaterThan(1);
+  });
+
   test('artwork editor renders the css-doodle and controls', async ({
     page,
   }) => {

--- a/lib/artwork.ts
+++ b/lib/artwork.ts
@@ -46,6 +46,10 @@ export type GalleryItem = {
   slug: string;
   name: string;
   white: boolean;
+  /** Everything the gallery needs to render a live css-doodle thumbnail. */
+  palette: string[];
+  options: ArtworkOption[];
+  code: Artwork['code'];
 };
 
 const artworksPath = path.join(process.cwd(), 'artworks');
@@ -78,8 +82,18 @@ export async function getGalleryItems(): Promise<GalleryItem[]> {
       slug: artwork.slug,
       name: artwork.name,
       white: artwork.galleryWhite ?? false,
+      palette: artwork.palette ?? [],
+      options: artwork.options,
+      code: artwork.code,
       order: artwork.galleryOrder ?? Number.MAX_SAFE_INTEGER,
     }))
     .sort((a, b) => a.order - b.order || a.name.localeCompare(b.name))
-    .map(({ slug, name, white }) => ({ slug, name, white }));
+    .map(({ slug, name, white, palette, options, code }) => ({
+      slug,
+      name,
+      white,
+      palette,
+      options,
+      code,
+    }));
 }

--- a/lib/doodleSource.ts
+++ b/lib/doodleSource.ts
@@ -1,0 +1,79 @@
+// Shared helper for turning an artwork definition into concrete css-doodle
+// source. Used by both the editor (EditArtwork) and the gallery thumbnails
+// (GalleryDoodle) so the substitution rules stay in one place.
+import type { ArtworkOption } from 'lib/artwork';
+
+export type OptionValue = string | number | boolean;
+
+// css-doodle >= 0.5 reads `@random(1)` as a one-cell count rather than a 100%
+// probability gate (fractional values still behave as probabilities). The
+// artwork definitions were authored against css-doodle 0.12 where `@random(1)`
+// meant "every cell", so nudge the fully-on case just under 1 to preserve the
+// original look at maximum frequency.
+export const fixFullRandomGate = (code: string): string =>
+  code.replace(/@random\s*\(\s*1(?:\.0+)?\s*\)/g, '@random(0.999)');
+
+const getColorsStyleCode = (colors: string[]): string =>
+  colors.map((color, idx) => `--color${idx}: ${color};\n`).join('');
+
+export type DoodleSourceInput = {
+  code: { style: string; doodle: string };
+  options: ArtworkOption[];
+  palette: string[];
+  optionValues: OptionValue[];
+  /** Canvas size as CSS lengths, e.g. "360px" / "100%". */
+  width: string;
+  height: string;
+};
+
+// Build the css-doodle style + rules for an artwork by substituting its option
+// placeholders, canvas size and palette. The generated pattern depends only on
+// the seed and grid, so the same inputs render identically at any size.
+export function buildDoodleSource({
+  code,
+  options,
+  palette,
+  optionValues,
+  width,
+  height,
+}: DoodleSourceInput): { styleCode: string; doodleCode: string } {
+  let styleCode = code.style;
+  let doodleCode = code.doodle;
+
+  options.forEach((option, index) => {
+    switch (option.type) {
+      case 'ButtonSelectGroup':
+      case 'Slider':
+        styleCode = styleCode
+          .split(option.replace)
+          .join(String(optionValues[index]));
+        doodleCode = doodleCode
+          .split(option.replace)
+          .join(String(optionValues[index]));
+        break;
+      case 'ToggleSwitch':
+        if (optionValues[index]) {
+          styleCode = styleCode.split(option.replace).join(option.code ?? '');
+          doodleCode = doodleCode
+            .split(option.replace)
+            .join(String(optionValues[index]));
+        } else {
+          styleCode = styleCode.split(option.replace).join('');
+          doodleCode = doodleCode.split(option.replace).join('');
+        }
+        break;
+      default:
+        break;
+    }
+  });
+
+  doodleCode = doodleCode.split('${width}').join(width);
+  doodleCode = doodleCode.split('${height}').join(height);
+
+  styleCode = fixFullRandomGate(styleCode);
+  doodleCode = fixFullRandomGate(doodleCode);
+
+  styleCode = getColorsStyleCode(palette) + styleCode;
+
+  return { styleCode, doodleCode };
+}


### PR DESCRIPTION
## What

Replaces the static raster gallery thumbnails (`public/images/thumb_<slug>.png`) with **live css-doodle**, rebuilt from each design's own rules. Applies to both the **select-artwork** gallery (all 11 designs) and the homepage **Browse artwork** section (first 7 + the existing "View All" card).

These are static for now (fixed seed per design); the intent is to make them interactive later, so each thumbnail is rendered from the real artwork code rather than a one-off.

## How

- **`lib/doodleSource.ts`** — extracts the editor's doodle-source builder (option substitution, the `@random(1)` shim, palette injection) into a shared helper. `EditArtwork` now delegates to it, so there's a single source of truth and no behaviour change in the editor.
- **`galleryThumbnails.ts`** — per-design thumbnail settings: background/palette, grid density, frequency, seed, and an optional crop. Palettes and densities were derived by sampling the original `thumb_*.png` images so the live versions match them closely. (Exact placement can't be reproduced since css-doodle is seeded-random — a "close enough" seed is pinned per design, per the request.)
- **`GalleryDoodle` / `GalleryDoodleInner`** — client components (css-doodle is a browser custom element, so loaded `ssr:false`). Each design is rendered at a fixed resolution and scaled to fit the square card, which keeps fixed-px strokes/shadows (e.g. Ring borders, Bloks shadows) in the proportions of the original 800px art. The square frame is rendered outside the lazy boundary so the card reserves its space (no layout shift).
- **Symmetry** — shown at circularity 1 with only its top half cropped in, as specified.
- **`GalleryItem`** now carries the `palette` / `options` / `code` the thumbnails need.

## Notes

- The `thumb_*.png` assets are left in place (still used by the "View All" card and harmless otherwise).
- `EditArtwork`, the editor, and gallery navigation are unchanged in behaviour.

## Testing

- `next build` passes.
- All existing Playwright smoke tests pass, plus a new test asserting the select-artwork gallery renders css-doodle thumbnails that actually paint cells.
- Verified visually in both dev and production builds; all 11 thumbnails closely match the original raster designs.

https://claude.ai/code/session_0163N3PAWmkwdshVHRRRGNxa

---
_Generated by [Claude Code](https://claude.ai/code/session_0163N3PAWmkwdshVHRRRGNxa)_