### PR TITLE
Fix mobile/desktop UX issues found in artwork-creation flow audit

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,7 +33,24 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        {/* proxima-nova (Adobe Fonts). Linked here instead of an @import in
+            globals.css so the browser discovers it from the HTML right away
+            (an @import is only found after the CSS bundle downloads), and
+            preconnected so the font files skip connection setup. React hoists
+            both links into <head>; stylesheets need `precedence` for that. */}
+        <link
+          rel="preconnect"
+          href="https://use.typekit.net"
+          crossOrigin="anonymous"
+        />
+        <link
+          rel="stylesheet"
+          href="https://use.typekit.net/nws2bge.css"
+          precedence="default"
+        />
+        {children}
+      </body>
     </html>
   );
 }

--- a/components/Doodle/index.tsx
+++ b/components/Doodle/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, type RefObject } from 'react';
+import { useEffect, useRef, type RefObject } from 'react';
 import 'css-doodle';
 
 type DoodleProps = {
@@ -18,12 +18,23 @@ export default function Doodle({
   doodleCode,
   doodleRef,
 }: DoodleProps) {
-  // css-doodle >= 0.5 no longer re-reads the element's text content on a bare
-  // update(), so pass the current source explicitly whenever the rules,
-  // palette, or seed change to make sure the grid is regenerated.
+  const renderedSource = useRef<string | null>(null);
+
+  // css-doodle renders the element's text content on mount and re-renders by
+  // itself when the observed `seed` attribute changes, so an explicit update()
+  // is only needed when the source (rules or palette) changes afterwards —
+  // anything more would regenerate every grid twice. css-doodle >= 0.5 no
+  // longer re-reads the text content on a bare update(), so pass the current
+  // source explicitly.
   useEffect(() => {
-    doodleRef.current?.update?.(doodleCode);
-  }, [doodleRef, doodleCode, styleCode, seed]);
+    const source = `${styleCode}\u0000${doodleCode}`;
+
+    if (renderedSource.current !== null && renderedSource.current !== source) {
+      doodleRef.current?.update?.(doodleCode);
+    }
+
+    renderedSource.current = source;
+  }, [doodleRef, doodleCode, styleCode]);
 
   return (
     <div>

--- a/components/edit-artwork-page/EditArtwork.tsx
+++ b/components/edit-artwork-page/EditArtwork.tsx
@@ -146,18 +146,62 @@ export default function EditArtwork({ artwork }: { artwork: Artwork }) {
   // A preset may pin itself to a single aspect ratio (e.g. Symmetry), in which
   // case the selector is hidden and the ratio can't change.
   const lockedAspectRatio = artwork.lockAspectRatio ?? null;
-  const initialAspectRatio =
+  const defaultAspectRatio =
     lockedAspectRatio ?? artwork.defaultAspectRatio ?? DEFAULT_ASPECT_RATIO;
 
-  const [palette, setPalette] = useState<string[]>(artwork.palette ?? []);
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  // The value an option takes according to the URL, falling back to the
+  // authored default when the param is absent or malformed (a hand-edited URL
+  // must not feed NaN into a slider, which would blank the control).
+  const optionFromQuery = (option: ArtworkOption): OptionValue => {
+    const queryVal = searchParams.get(option.id);
+
+    if (queryVal === null) {
+      return option.default;
+    }
+
+    if (typeof option.default === 'number') {
+      const numericVal = Number(queryVal);
+
+      return Number.isNaN(numericVal) ? option.default : numericVal;
+    }
+
+    if (typeof option.default === 'boolean') {
+      return queryVal === 'true';
+    }
+
+    return queryVal;
+  };
+
+  const paletteFromQuery = (): string[] => {
+    const queryPalette = searchParams.getAll('palette');
+
+    return artwork.palette && queryPalette.length === artwork.palette.length
+      ? queryPalette
+      : artwork.palette ?? [];
+  };
+
+  const aspectRatioFromQuery = (): AspectRatioId => {
+    const queryRatio = searchParams.get('aspectRatio');
+
+    return !lockedAspectRatio && queryRatio && isAspectRatioId(queryRatio)
+      ? queryRatio
+      : defaultAspectRatio;
+  };
+
+  // State starts from the URL (shared / refreshed links) and falls back to the
+  // artwork defaults, so the first paint already shows the linked artwork
+  // instead of correcting itself after mount.
+  const [palette, setPalette] = useState<string[]>(paletteFromQuery);
   const [optionValues, setOptionValues] = useState<OptionValue[]>(() =>
-    artwork.options.map((option) => option.default)
+    artwork.options.map((option) => optionFromQuery(option))
   );
   const [aspectRatio, setAspectRatio] =
-    useState<AspectRatioId>(initialAspectRatio);
-  const [styleCode, setStyleCode] = useState('');
-  const [doodleCode, setDoodleCode] = useState('');
-  const [seed, setSeed] = useState('0000');
+    useState<AspectRatioId>(aspectRatioFromQuery);
+  const [seed, setSeed] = useState(() => searchParams.get('seed') ?? '0000');
   const [isExpanded, setIsExpanded] = useState(false);
   const [viewport, setViewport] = useState<{
     width: number;
@@ -170,9 +214,6 @@ export default function EditArtwork({ artwork }: { artwork: Artwork }) {
   const doodleRef = useRef<any>(null);
   const expandedDoodleRef = useRef<any>(null);
   const previewRef = useRef<HTMLDivElement>(null);
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
   const isScreenXS = useMediaQuery('(max-width: 747.99px)');
   const isTwoColumn = useMediaQuery('(min-width: 992px)');
   const baseWidth = isScreenXS ? 240 : 360;
@@ -191,61 +232,37 @@ export default function EditArtwork({ artwork }: { artwork: Artwork }) {
       )
     : fitToBox(aspectRatio, baseWidth, baseWidth * 1.5);
 
-  // Sync component state FROM the URL search params.
+  // Sync component state FROM the URL search params after mount (back /
+  // forward navigation re-renders with new params without remounting). Each
+  // setter is guarded so an echo of our own router.replace is a no-op.
   useEffect(() => {
-    const queryPalette = searchParams.getAll('palette');
+    const queryPalette = paletteFromQuery();
 
-    if (
-      artwork.palette &&
-      queryPalette.length === artwork.palette.length &&
-      !arraysEqual(palette, queryPalette)
-    ) {
+    if (!arraysEqual(palette, queryPalette)) {
       setPalette(queryPalette);
     }
 
     artwork.options.forEach((option, optionIndex) => {
-      if (!searchParams.has(option.id)) {
-        return;
-      }
+      const queryVal = optionFromQuery(option);
 
-      const queryVal = searchParams.get(option.id) ?? '';
-
-      if (typeof option.default === 'string') {
+      if (queryVal !== optionValues[optionIndex]) {
         setOptionByIndex(optionIndex, queryVal);
-      } else if (typeof option.default === 'number') {
-        const numericVal = Number(queryVal);
-
-        // Ignore malformed numbers so a hand-edited URL can't feed NaN into a
-        // slider (which would blank the control).
-        if (!Number.isNaN(numericVal)) {
-          setOptionByIndex(optionIndex, numericVal);
-        }
-      } else if (typeof option.default === 'boolean') {
-        setOptionByIndex(optionIndex, queryVal === 'true');
       }
     });
 
-    if (searchParams.has('seed') && seed !== searchParams.get('seed')) {
-      setSeed(searchParams.get('seed') as string);
+    const querySeed = searchParams.get('seed') ?? '0000';
+
+    if (seed !== querySeed) {
+      setSeed(querySeed);
     }
 
-    const queryAspectRatio = searchParams.get('aspectRatio');
+    const queryAspectRatio = aspectRatioFromQuery();
 
-    if (
-      !lockedAspectRatio &&
-      queryAspectRatio &&
-      isAspectRatioId(queryAspectRatio) &&
-      queryAspectRatio !== aspectRatio
-    ) {
+    if (queryAspectRatio !== aspectRatio) {
       setAspectRatio(queryAspectRatio);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams]);
-
-  useEffect(() => {
-    updateDoodleCode();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [palette, optionValues, aspectRatio, width, height]);
 
   // Track the viewport so the expanded dialog can size the artwork to fit.
   useEffect(() => {
@@ -360,12 +377,9 @@ export default function EditArtwork({ artwork }: { artwork: Artwork }) {
       height: `${canvasHeight}px`,
     });
 
-  const updateDoodleCode = () => {
-    const source = buildSource(width, height);
-
-    setStyleCode(source.styleCode);
-    setDoodleCode(source.doodleCode);
-  };
+  // Derived straight from state (cheap string substitution), so the preview
+  // can never lag a render behind the controls.
+  const { styleCode, doodleCode } = buildSource(width, height);
 
   const getOptionControlComponent = (
     option: ArtworkOption,

--- a/components/edit-artwork-page/EditArtworkHeader.tsx
+++ b/components/edit-artwork-page/EditArtworkHeader.tsx
@@ -28,13 +28,20 @@ export default function EditArtworkHeader({
 
           <Col md={4} xs={6}>
             <div className="align-right">
-              <button className={styles.btn} onClick={onRedraw}>
+              {/* aria-labels keep the buttons named on small screens, where
+                  the text labels are hidden and only the icons remain. */}
+              <button
+                className={styles.btn}
+                onClick={onRedraw}
+                aria-label="Redraw"
+              >
                 <RefreshCw className={styles.reactIcon} size={18} />
                 <span className={styles.label}>Redraw</span>
               </button>
               <button
                 className={`${styles.btn} ${styles.btnExport}`}
                 onClick={onExport}
+                aria-label="Export"
               >
                 <ArrowDownToLine className={styles.reactIcon} size={18} />
                 <span className={styles.label}>Export</span>

--- a/components/main-page/BrowseArtwork.tsx
+++ b/components/main-page/BrowseArtwork.tsx
@@ -27,7 +27,11 @@ export default async function BrowseArtworkSection() {
         <Row noGutter>
           {gallery.map((item) => (
             <Col key={item.slug} md={3} sm={6}>
-              <Link href={`/artwork/${item.slug}/`}>
+              {/* The seed param matches the select-artwork links: the editor
+                  only mirrors customizations into the URL (making them
+                  shareable and refresh-safe) when the URL already carries a
+                  query param. */}
+              <Link href={`/artwork/${item.slug}?seed=0000`}>
                 <div className={styles.galleryCard}>
                   <h4 className={item.white ? styles.white : undefined}>
                     {item.name}

--- a/components/main-page/Hero.tsx
+++ b/components/main-page/Hero.tsx
@@ -9,12 +9,53 @@ import styles from './Hero.module.css';
 export default function MainHero() {
   const doodleRef = useRef<any>(null);
 
+  // Re-randomize the backdrop every couple of seconds, but only while it can
+  // actually be seen: pause when the hero is scrolled away or the tab is
+  // hidden (each update re-renders the whole doodle grid), and stay still for
+  // users who prefer reduced motion.
   useEffect(() => {
-    const timer = setInterval(() => {
-      doodleRef.current?.update();
-    }, 2000);
+    const doodleElement = doodleRef.current;
 
-    return () => clearInterval(timer);
+    if (!doodleElement) {
+      return;
+    }
+
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+    let isInView = false;
+    let timer: ReturnType<typeof setInterval> | null = null;
+
+    const sync = () => {
+      const shouldAnimate =
+        isInView && !document.hidden && !reducedMotion.matches;
+
+      if (shouldAnimate && timer === null) {
+        timer = setInterval(() => {
+          doodleRef.current?.update();
+        }, 2000);
+      } else if (!shouldAnimate && timer !== null) {
+        clearInterval(timer);
+        timer = null;
+      }
+    };
+
+    const observer = new IntersectionObserver((entries) => {
+      isInView = entries[0].isIntersecting;
+      sync();
+    });
+
+    observer.observe(doodleElement);
+    document.addEventListener('visibilitychange', sync);
+    reducedMotion.addEventListener('change', sync);
+
+    return () => {
+      observer.disconnect();
+      document.removeEventListener('visibilitychange', sync);
+      reducedMotion.removeEventListener('change', sync);
+
+      if (timer !== null) {
+        clearInterval(timer);
+      }
+    };
   }, []);
 
   return (

--- a/components/select-artwork-page/GalleryDoodleInner.tsx
+++ b/components/select-artwork-page/GalleryDoodleInner.tsx
@@ -46,10 +46,17 @@ export default function GalleryDoodleInner({ item }: { item: GalleryItem }) {
     return () => observer.disconnect();
   }, []);
 
-  // css-doodle >= 0.5 no longer re-reads text content on a bare update(), so
-  // push the current source whenever it changes.
+  // css-doodle renders its text content on mount, so only push the source on
+  // later changes (css-doodle >= 0.5 no longer re-reads the text on a bare
+  // update()). Skipping the mount avoids regenerating every thumbnail twice.
+  const renderedCode = useRef<string | null>(null);
+
   useEffect(() => {
-    doodleRef.current?.update?.(doodleCode);
+    if (renderedCode.current !== null && renderedCode.current !== doodleCode) {
+      doodleRef.current?.update?.(doodleCode);
+    }
+
+    renderedCode.current = doodleCode;
   }, [doodleCode]);
 
   // Cover-fit the (possibly cropped) render into the square card. Scaling the

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -174,4 +174,51 @@ test.describe('Tabbied site', () => {
       page.getByRole('heading', { name: 'iOS Export Test' })
     ).toBeVisible();
   });
+
+  test('homepage gallery cards link with a seed so edits sync to the URL', async ({
+    page,
+  }) => {
+    await page.goto('/');
+
+    // Without a query param on the link, the editor never mirrors state into
+    // the URL, so customizations made after entering from the homepage would
+    // not survive a refresh or be shareable.
+    await page
+      .locator('#section-browse-artwork a[href*="/artwork/radius"]')
+      .click();
+
+    await page.waitForURL(/\/artwork\/radius\?/, { timeout: 15000 });
+    await expect(page).toHaveURL(/seed=0000/);
+
+    await page.getByText('6x9', { exact: true }).click();
+    await expect(page).toHaveURL(/grid=6x9/);
+  });
+
+  test('editor opens directly in the state described by a shared URL', async ({
+    page,
+  }) => {
+    await page.goto('/artwork/radius?seed=ZZZZ&grid=9x9&aspectRatio=1%3A1');
+
+    // Initial state comes from the URL (not corrected after mount), so the
+    // matching grid option must already be selected.
+    await expect(page.getByText('9x9', { exact: true })).toBeVisible();
+    const pressed = page.locator('[data-pressed]', { hasText: '9x9' });
+    await expect(pressed).toHaveCount(1);
+  });
+});
+
+test.describe('Tabbied site (mobile viewport)', () => {
+  test.use({ viewport: { width: 390, height: 664 } });
+
+  test('icon-only header buttons keep accessible names', async ({ page }) => {
+    await page.goto('/artwork/radius?seed=0000');
+
+    // Below the md breakpoint the text labels are display:none, leaving
+    // icon-only buttons — they must still expose an accessible name.
+    await expect(page.getByRole('button', { name: 'Redraw' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Export' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Redraw' }).click();
+    await expect(page).not.toHaveURL(/seed=0000/);
+  });
 });

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,4 +1,7 @@
-@import url('https://use.typekit.net/nws2bge.css');
+/* The proxima-nova (Adobe Fonts / typekit) stylesheet is linked from the root
+   layout <head> with a preconnect, rather than @imported here — an @import is
+   only discovered after this bundle downloads, which serializes the requests
+   and delays first paint. */
 
 /*
  * minireset.css (MIT, https://github.com/jgthms/minireset.css), vendored inline

--- a/styles/pickr.css
+++ b/styles/pickr.css
@@ -48,6 +48,23 @@
   position: fixed;
 }
 
+/*
+ * On small screens the popup routinely overflows the bottom of the viewport
+ * (pickr positions it under the swatch and re-anchors it there on scroll), so
+ * the hue/opacity sliders and the save button could be impossible to reach.
+ * Pin it to the bottom of the screen as a sheet instead; !important is needed
+ * to beat the inline left/top pickr sets while positioning.
+ */
+@media (max-width: 991.98px) {
+  .pcr-app[data-theme='monolith'] {
+    top: auto !important;
+    bottom: calc(0.75rem + env(safe-area-inset-bottom)) !important;
+    left: 50% !important;
+    transform: translateX(-50%);
+    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.25);
+  }
+}
+
 .pcr-app[data-theme='monolith'] .pcr-interaction input,
 .pcr-app[data-theme='monolith'] .pcr-interaction .pcr-result {
   border-radius: 2px;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,11 @@
       "dom.iterable",
       "esnext"
     ],
-    "baseUrl": ".",
+    "paths": {
+      "components/*": ["./components/*"],
+      "lib/*": ["./lib/*"],
+      "styles/*": ["./styles/*"]
+    },
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,


### PR DESCRIPTION
# UX audit: landing → gallery → editor → export

Walked the full visitor flow in desktop (1440×900) and mobile (iPhone 13) viewports with Playwright, screenshotting and instrumenting every step, then fixed what the audit surfaced.

## User-facing fixes

### Mobile color picker was effectively unusable
The pickr popup (`position: fixed`) opens below the swatch and routinely overflows the viewport on phones — measured opening at y=608 with 316px height in a 664px viewport, hiding the hue/opacity sliders, the hex input, and the **Save button (the only way to apply a color)**. Because pickr re-anchors the popup under the swatch on every scroll, scrolling never reveals the hidden part. Below the `md` breakpoint the picker is now pinned to the bottom of the screen as a sheet (with safe-area inset); desktop behavior is unchanged (still anchored to the swatch).

### Icon-only buttons had no accessible name on mobile
Below 992px the Redraw/Export text labels are `display: none`, leaving icon-only buttons that expose no name to assistive tech. Added `aria-label`s.

### Customizations were lost when entering from the homepage
The editor only mirrors state into the URL once the URL carries a query param. The homepage "Browse artwork" cards linked without one (`/artwork/radius/`), so edits made via that entry path weren't shareable and didn't survive a refresh — unlike the select-artwork gallery path. Homepage cards now link with `?seed=0000`, matching the gallery.

### Shared links now paint correctly on first render
Editor state is initialized from the URL params instead of being corrected by a post-mount effect, so a shared/refreshed link renders the linked artwork immediately rather than flashing defaults first.

## Performance fixes

- **Every doodle rendered twice.** css-doodle re-renders itself when the observed `seed` attribute changes and parses its text content on mount, so the explicit `update()` on mount/seed-change regenerated each grid a second time — editor preview, expanded dialog, and all 11 live gallery thumbnails. `update()` now only fires when the source actually changes after mount (verified by instrumenting `update()`: 0 calls on Redraw, exactly 1 on an option change).
- **Hero animation ran forever.** The every-2s re-randomization of the hero doodle kept burning CPU while scrolled away or with the tab hidden, and ignored `prefers-reduced-motion`. The interval is now gated by IntersectionObserver + `visibilitychange` + reduced-motion (verified: 0 updates while scrolled away).
- **Render-blocking font @import.** The typekit stylesheet was an `@import` at the top of the CSS bundle, only discoverable after the bundle downloaded. It's now a preconnected `<link rel="stylesheet">` hoisted into `<head>` from the root layout.
- **Editor state churn.** The doodle source is derived during render instead of mirrored through state+effect (removing an extra render per change plus an empty first paint), and the URL→state sync is guarded so echoes of our own `router.replace` no longer rebuild option state.

## Housekeeping

- `tsconfig.json`: migrated the deprecated `baseUrl` (hard error under TS 6) to explicit `paths`, so `npx tsc --noEmit` is clean again.

## Tests

Three new e2e regression tests: homepage entry path syncs edits to the URL, shared URLs open in the described state, and icon-only header buttons keep accessible names at mobile width. **12/12 passing** against the production build; manual verification additionally covered color-pick-and-save on mobile, expand dialog, and PNG export (3170×3170 desktop / 2151×3231 mobile downloads succeed) in both viewports.

https://claude.ai/code/session_01Ens6qvWFK9CzNbTxfEjba9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ens6qvWFK9CzNbTxfEjba9)_