### PR TITLE
Add 10 new generative artwork presets

### DIFF
--- a/artworks/arco.json
+++ b/artworks/arco.json
@@ -1,0 +1,31 @@
+{
+  "name": "Arco",
+  "slug": "arco",
+  "galleryOrder": 17,
+  "description": "Concentric rainbow arches spring from the edges of each cell, facing whichever way the seed decides.",
+  "palette": ["#FFFFFF", "#FF3D8B", "#3E8BFF", "#F5DD32", "#3FFFB2", "#3EECFF"],
+  "options": [
+    {
+      "id": "grid",
+      "displayName": "Columns and rows",
+      "type": "ButtonSelectGroup",
+      "default": "4x6",
+      "options": ["2x3", "4x6", "6x9", "8x12", "10x15"],
+      "replace": "${grid}"
+    },
+    {
+      "id": "frequency",
+      "displayName": "Frequency",
+      "type": "Slider",
+      "default": 1,
+      "min": 0.2,
+      "max": 1,
+      "step": 0.1,
+      "replace": "${shapeFrequency}"
+    }
+  ],
+  "code": {
+    "style": "/* Three independent band colors per arch */ --randomColor: @p(var(--color1), var(--color2), var(--color3), var(--color4), var(--color5)); --randomColor2: @p(var(--color1), var(--color2), var(--color3), var(--color4), var(--color5)); --randomColor3: @p(var(--color1), var(--color2), var(--color3), var(--color4), var(--color5)); --rule: ( /*Frequency options of 0.2, 0.4, 0.6, 0.8, 1.0 */ @random(${shapeFrequency}) { /* Double-position stops keep each band a single color — css-doodle re-rolls @p vars per occurrence, so repeating a stop would blur the bands */ background: radial-gradient(circle farthest-side at 50% 100%, var(--randomColor) 0% 22%, var(--randomColor2) 22% 44%, var(--randomColor3) 44% 66%, transparent 66% 100%); -webkit-transform: rotate(@pick(0deg, 90deg, 180deg, 270deg)); transform: rotate(@pick(0deg, 90deg, 180deg, 270deg)); -webkit-transition: ease 400ms; transition: ease 400ms; } /* Now and then a sun instead of an arch */ @random(0.1) { background: radial-gradient(circle farthest-side at 50% 50%, var(--randomColor2) 0% 28%, transparent 28% 100%); -webkit-transform: none; transform: none; } );",
+    "doodle": ":doodle { @grid: ${grid}; @size: ${width} ${height}; overflow:hidden; text-align:center; box-sizing:border-box } :container { background: var(--color0); overflow:hidden; }"
+  }
+}

--- a/artworks/confetti.json
+++ b/artworks/confetti.json
@@ -1,0 +1,31 @@
+{
+  "name": "Confetti",
+  "slug": "confetti",
+  "galleryOrder": 15,
+  "description": "Circles, triangles, squares and paper strips tossed across the canvas at random sizes and angles — a celebration frozen mid-air.",
+  "palette": ["#FFFFFF", "#FF3D8B", "#3E8BFF", "#3FFFB2", "#F5DD32", "#3EECFF"],
+  "options": [
+    {
+      "id": "grid",
+      "displayName": "Columns and rows",
+      "type": "ButtonSelectGroup",
+      "default": "4x6",
+      "options": ["2x3", "4x6", "6x9", "8x12", "10x15"],
+      "replace": "${grid}"
+    },
+    {
+      "id": "frequency",
+      "displayName": "Frequency",
+      "type": "Slider",
+      "default": 1,
+      "min": 0.2,
+      "max": 1,
+      "step": 0.1,
+      "replace": "${shapeFrequency}"
+    }
+  ],
+  "code": {
+    "style": "/* Random color generator variable */ --randomColor: @p(var(--color1), var(--color2), var(--color3), var(--color4), var(--color5)); --rule: ( /*Frequency options of 0.2, 0.4, 0.6, 0.8, 1.0 */ @random(${shapeFrequency}) { :after { content: ''; position: absolute; @size: @rand(18%, 55%); left: @rand(2%, 60%); top: @rand(2%, 60%); background: var(--randomColor); -webkit-clip-path: @pick(circle(50% at 50% 50%), polygon(50% 0, 100% 100%, 0 100%), polygon(0 0, 100% 0, 100% 100%, 0 100%), inset(32% 0 32% 0)); clip-path: @pick(circle(50% at 50% 50%), polygon(50% 0, 100% 100%, 0 100%), polygon(0 0, 100% 0, 100% 100%, 0 100%), inset(32% 0 32% 0)); -webkit-transform: rotate(@rand(0deg, 359deg)); transform: rotate(@rand(0deg, 359deg)); -webkit-transition: ease 400ms; transition: ease 400ms; } } );",
+    "doodle": ":doodle { @grid: ${grid}; @size: ${width} ${height}; overflow:hidden; text-align:center; box-sizing:border-box } :container { background: var(--color0); overflow:hidden; }"
+  }
+}

--- a/artworks/foliage.json
+++ b/artworks/foliage.json
@@ -1,0 +1,39 @@
+{
+  "name": "Foliage",
+  "slug": "foliage",
+  "galleryOrder": 16,
+  "description": "Gradient leaf shapes rotate through the grid, with the occasional berry tucked in between.",
+  "palette": ["#FFFFFF", "#3FFFB2", "#3E8BFF", "#9EFFD8", "#FF3D8B", "#F5DD32"],
+  "options": [
+    {
+      "id": "grid",
+      "displayName": "Columns and rows",
+      "type": "ButtonSelectGroup",
+      "default": "4x6",
+      "options": ["2x3", "4x6", "6x9", "8x12", "10x15"],
+      "replace": "${grid}"
+    },
+    {
+      "id": "frequency",
+      "displayName": "Frequency",
+      "type": "Slider",
+      "default": 1,
+      "min": 0.2,
+      "max": 1,
+      "step": 0.1,
+      "replace": "${shapeFrequency}"
+    },
+    {
+      "id": "shadow",
+      "displayName": "Shadow",
+      "type": "ToggleSwitch",
+      "default": false,
+      "code": "-webkit-box-shadow:0 0 40px rgba(0,0,0,0.2); box-shadow:0 0 40px rgba(0,0,0,0.2);",
+      "replace": "${shadow}"
+    }
+  ],
+  "code": {
+    "style": "/* Independent colors for the two ends of each leaf gradient */ --randomColor: @p(var(--color1), var(--color2), var(--color3), var(--color4), var(--color5)); --randomColor2: @p(var(--color1), var(--color2), var(--color3), var(--color4), var(--color5)); --rule: ( /*Frequency options of 0.2, 0.4, 0.6, 0.8, 1.0 */ @random(${shapeFrequency}) { width: 88%; height: 88%; margin: 6%; background: linear-gradient(135deg, var(--randomColor), var(--randomColor2)); /* Two rounded opposite corners make the leaf */ border-radius: 0 100%; -webkit-transform: rotate(@pick(0deg, 90deg)); transform: rotate(@pick(0deg, 90deg)); /* On or off option for displaying box shadows */ ${shadow} -webkit-transition: ease 400ms; transition: ease 400ms; } /* Occasionally a leaf gives way to a small berry */ @random(0.12) { width: 38%; height: 38%; margin: 31%; border-radius: 50%; background: var(--randomColor2); -webkit-transform: none; transform: none; } );",
+    "doodle": ":doodle { @grid: ${grid}; @size: ${width} ${height}; overflow:hidden; text-align:center; box-sizing:border-box } :container { background: var(--color0); overflow:hidden; }"
+  }
+}

--- a/artworks/maze.json
+++ b/artworks/maze.json
@@ -1,0 +1,41 @@
+{
+  "name": "Maze",
+  "slug": "maze",
+  "galleryOrder": 12,
+  "description": "A nod to the classic 10 PRINT one-liner: diagonal strokes tumble across the grid to form an endless maze, with the occasional junction dot.",
+  "palette": ["#FFFFFF", "#232529", "#3E8BFF", "#FF3D8B", "#3FFFB2", "#3EECFF"],
+  "options": [
+    {
+      "id": "grid",
+      "displayName": "Columns and rows",
+      "type": "ButtonSelectGroup",
+      "default": "8x12",
+      "options": ["2x3", "4x6", "6x9", "8x12", "10x15"],
+      "replace": "${grid}"
+    },
+    {
+      "id": "frequency",
+      "displayName": "Frequency",
+      "type": "Slider",
+      "default": 1,
+      "min": 0.2,
+      "max": 1,
+      "step": 0.1,
+      "replace": "${shapeFrequency}"
+    },
+    {
+      "id": "thickness",
+      "displayName": "Stroke thickness",
+      "type": "Slider",
+      "default": 8,
+      "min": 4,
+      "max": 14,
+      "step": 1,
+      "replace": "${strokeWidth}"
+    }
+  ],
+  "code": {
+    "style": "/* Mostly-dark strokes with occasional accent colors */ --randomColor: @p(var(--color1), var(--color1), var(--color1), var(--color2), var(--color3), var(--color4), var(--color5)); --rule: ( /*Frequency options of 0.2, 0.4, 0.6, 0.8, 1.0 */ @random(${shapeFrequency}) { background: linear-gradient(@pick(45deg, -45deg), transparent calc(50% - ${strokeWidth}%), var(--randomColor) calc(50% - ${strokeWidth}%), var(--randomColor) calc(50% + ${strokeWidth}%), transparent calc(50% + ${strokeWidth}%)); -webkit-transition: ease 400ms; transition: ease 400ms; } /* Occasional junction dots break up the lines */ @random(0.08) { background: none; :after { content: ''; position: absolute; @size: calc(${strokeWidth}% * 2.6); left: 50%; top: 50%; -webkit-transform: translate(-50%, -50%); transform: translate(-50%, -50%); border-radius: 50%; background: var(--randomColor); } } );",
+    "doodle": ":doodle { @grid: ${grid}; @size: ${width} ${height}; overflow:hidden; text-align:center; box-sizing:border-box } :container { background: var(--color0); overflow:hidden; }"
+  }
+}

--- a/artworks/metro.json
+++ b/artworks/metro.json
@@ -1,0 +1,32 @@
+{
+  "name": "Metro",
+  "slug": "metro",
+  "galleryOrder": 18,
+  "galleryWhite": true,
+  "description": "Quarter-circle arcs meet at the cell edges to sketch a tangled transit map of neon lines and stations on a navy night.",
+  "palette": ["#1B4075", "#3EECFF", "#3FFFB2", "#FF3D8B", "#FFFFFF", "#F5DD32"],
+  "options": [
+    {
+      "id": "grid",
+      "displayName": "Columns and rows",
+      "type": "ButtonSelectGroup",
+      "default": "6x9",
+      "options": ["2x3", "4x6", "6x9", "8x12", "10x15"],
+      "replace": "${grid}"
+    },
+    {
+      "id": "frequency",
+      "displayName": "Frequency",
+      "type": "Slider",
+      "default": 1,
+      "min": 0.2,
+      "max": 1,
+      "step": 0.1,
+      "replace": "${shapeFrequency}"
+    }
+  ],
+  "code": {
+    "style": "/* Independent colors for the two arc layers */ --randomColor: @p(var(--color1), var(--color2), var(--color3), var(--color4), var(--color5)); --randomColor2: @p(var(--color1), var(--color2), var(--color3), var(--color4), var(--color5)); --rule: ( /*Frequency options of 0.2, 0.4, 0.6, 0.8, 1.0 */ /* Strokes centered on the edge midpoints so arcs connect across cells */ @random(${shapeFrequency}) { background: radial-gradient(circle farthest-side at @pick('0% 0%', '100% 0%', '100% 100%', '0% 100%'), transparent 36%, var(--randomColor) 36%, var(--randomColor) 64%, transparent 64%); } /* A second arc layer weaves over the first */ @random(0.5) { :before { content: ''; position: absolute; left: 0; top: 0; @size: 100%; background: radial-gradient(circle farthest-side at @pick('0% 0%', '100% 0%', '100% 100%', '0% 100%'), transparent 36%, var(--randomColor2) 36%, var(--randomColor2) 64%, transparent 64%); } } /* Station dots */ @random(0.12) { :after { content: ''; position: absolute; @size: 22%; left: 39%; top: 39%; border-radius: 50%; background: var(--randomColor); } } );",
+    "doodle": ":doodle { @grid: ${grid}; @size: ${width} ${height}; overflow:hidden; text-align:center; box-sizing:border-box } :container { background: var(--color0); overflow:hidden; }"
+  }
+}

--- a/artworks/orbit.json
+++ b/artworks/orbit.json
@@ -1,0 +1,32 @@
+{
+  "name": "Orbit",
+  "slug": "orbit",
+  "galleryOrder": 14,
+  "galleryWhite": true,
+  "description": "Glowing rings on a midnight field, each with a small moon parked somewhere along its orbit.",
+  "palette": ["#232529", "#FFFFFF", "#3EECFF", "#FF3D8B", "#3FFFB2", "#F5DD32"],
+  "options": [
+    {
+      "id": "grid",
+      "displayName": "Columns and rows",
+      "type": "ButtonSelectGroup",
+      "default": "4x6",
+      "options": ["2x3", "4x6", "6x9", "8x12", "10x15"],
+      "replace": "${grid}"
+    },
+    {
+      "id": "frequency",
+      "displayName": "Frequency",
+      "type": "Slider",
+      "default": 1,
+      "min": 0.2,
+      "max": 1,
+      "step": 0.1,
+      "replace": "${shapeFrequency}"
+    }
+  ],
+  "code": {
+    "style": "/* Independent colors for the ring and its moon */ --randomColor: @p(var(--color1), var(--color2), var(--color3), var(--color4), var(--color5)); --randomColor2: @p(var(--color1), var(--color2), var(--color3), var(--color4), var(--color5)); --rule: ( /*Frequency options of 0.2, 0.4, 0.6, 0.8, 1.0 */ @random(${shapeFrequency}) { /* Rotating the whole cell moves the moon around the ring */ -webkit-transform: rotate(@pick(0deg, 45deg, 90deg, 135deg, 180deg, 225deg, 270deg, 315deg)); transform: rotate(@pick(0deg, 45deg, 90deg, 135deg, 180deg, 225deg, 270deg, 315deg)); -webkit-transition: ease 400ms; transition: ease 400ms; :before { content: ''; position: absolute; @size: 64%; left: 18%; top: 18%; /* ring thickness scales with the grid like Ring's border */ border: calc(84px / @size-row) solid var(--randomColor); border-radius: 50%; box-sizing: border-box; opacity: 0.85; } :after { content: ''; position: absolute; @size: 16%; left: 42%; top: 10%; background: var(--randomColor2); border-radius: 50%; } } );",
+    "doodle": ":doodle { @grid: ${grid}; @size: ${width} ${height}; overflow:hidden; text-align:center; box-sizing:border-box } :container { background: var(--color0); overflow:hidden; }"
+  }
+}

--- a/artworks/pinwheel.json
+++ b/artworks/pinwheel.json
@@ -1,0 +1,32 @@
+{
+  "name": "Pinwheel",
+  "slug": "pinwheel",
+  "galleryOrder": 13,
+  "galleryWhite": true,
+  "description": "Discs split into alternating quarter wedges spin at random angles, like a field of paper pinwheels caught mid-turn.",
+  "palette": ["#FFFFFF", "#3E8BFF", "#FF3D8B", "#3FFFB2", "#F5DD32", "#232529"],
+  "options": [
+    {
+      "id": "grid",
+      "displayName": "Columns and rows",
+      "type": "ButtonSelectGroup",
+      "default": "4x6",
+      "options": ["2x3", "4x6", "6x9", "8x12", "10x15"],
+      "replace": "${grid}"
+    },
+    {
+      "id": "frequency",
+      "displayName": "Frequency",
+      "type": "Slider",
+      "default": 1,
+      "min": 0.2,
+      "max": 1,
+      "step": 0.1,
+      "replace": "${shapeFrequency}"
+    }
+  ],
+  "code": {
+    "style": "/* Two independent colors per cell so the wedges alternate */ --randomColor: @p(var(--color1), var(--color2), var(--color3), var(--color4), var(--color5)); --randomColor2: @p(var(--color1), var(--color2), var(--color3), var(--color4), var(--color5)); --rule: ( /*Frequency options of 0.2, 0.4, 0.6, 0.8, 1.0 */ @random(${shapeFrequency}) { width: 86%; height: 86%; margin: 7%; border-radius: 50%; background: conic-gradient(from @pick(0deg, 45deg, 90deg, 135deg), var(--randomColor) 0deg, var(--randomColor) 90deg, var(--randomColor2) 90deg, var(--randomColor2) 180deg, var(--randomColor) 180deg, var(--randomColor) 270deg, var(--randomColor2) 270deg, var(--randomColor2) 360deg); -webkit-transition: ease 400ms; transition: ease 400ms; } /* Some pinwheels get a punched-out center hole */ @random(0.3) { :after { content: ''; position: absolute; left: 36%; top: 36%; @size: 28%; border-radius: 50%; background: var(--color0); } } );",
+    "doodle": ":doodle { @grid: ${grid}; @size: ${width} ${height}; overflow:hidden; text-align:center; box-sizing:border-box } :container { background: var(--color0); overflow:hidden; }"
+  }
+}

--- a/artworks/polka.json
+++ b/artworks/polka.json
@@ -1,0 +1,40 @@
+{
+  "name": "Polka",
+  "slug": "polka",
+  "galleryOrder": 19,
+  "galleryWhite": true,
+  "description": "Dots of every size bounce across the canvas — flip them hollow for a field of floating rings.",
+  "palette": ["#3E8BFF", "#FFFFFF", "#FF3D8B", "#3FFFB2", "#F5DD32", "#3EECFF"],
+  "options": [
+    {
+      "id": "grid",
+      "displayName": "Columns and rows",
+      "type": "ButtonSelectGroup",
+      "default": "4x6",
+      "options": ["2x3", "4x6", "6x9", "8x12", "10x15"],
+      "replace": "${grid}"
+    },
+    {
+      "id": "frequency",
+      "displayName": "Frequency",
+      "type": "Slider",
+      "default": 1,
+      "min": 0.2,
+      "max": 1,
+      "step": 0.1,
+      "replace": "${shapeFrequency}"
+    },
+    {
+      "id": "hollow",
+      "displayName": "Hollow",
+      "type": "ToggleSwitch",
+      "default": false,
+      "code": "background: transparent; border: calc(72px / @size-row) solid var(--randomColor); box-sizing: border-box;",
+      "replace": "${hollow}"
+    }
+  ],
+  "code": {
+    "style": "/* Random color generator variable */ --randomColor: @p(var(--color1), var(--color2), var(--color3), var(--color4), var(--color5)); --rule: ( /*Frequency options of 0.2, 0.4, 0.6, 0.8, 1.0 */ @random(${shapeFrequency}) { :after { content: ''; position: absolute; @size: @rand(22%, 86%); left: 50%; top: 50%; -webkit-transform: translate(-50%, -50%); transform: translate(-50%, -50%); border-radius: 50%; background: var(--randomColor); /* On or off option for hollow rings */ ${hollow} -webkit-transition: ease 400ms; transition: ease 400ms; } } );",
+    "doodle": ":doodle { @grid: ${grid}; @size: ${width} ${height}; overflow:hidden; text-align:center; box-sizing:border-box } :container { background: var(--color0); overflow:hidden; }"
+  }
+}

--- a/artworks/stitch.json
+++ b/artworks/stitch.json
@@ -1,0 +1,31 @@
+{
+  "name": "Stitch",
+  "slug": "stitch",
+  "galleryOrder": 20,
+  "description": "Plus signs and crosses stitched into the grid like embroidery, with a few knots scattered through the weave.",
+  "palette": ["#FFFFFF", "#FF3D8B", "#3E8BFF", "#3FFFB2", "#232529", "#F5DD32"],
+  "options": [
+    {
+      "id": "grid",
+      "displayName": "Columns and rows",
+      "type": "ButtonSelectGroup",
+      "default": "4x6",
+      "options": ["2x3", "4x6", "6x9", "8x12", "10x15"],
+      "replace": "${grid}"
+    },
+    {
+      "id": "frequency",
+      "displayName": "Frequency",
+      "type": "Slider",
+      "default": 1,
+      "min": 0.2,
+      "max": 1,
+      "step": 0.1,
+      "replace": "${shapeFrequency}"
+    }
+  ],
+  "code": {
+    "style": "/* Random color generator variable */ --randomColor: @p(var(--color1), var(--color2), var(--color3), var(--color4), var(--color5)); --rule: ( /*Frequency options of 0.2, 0.4, 0.6, 0.8, 1.0 */ @random(${shapeFrequency}) { background: var(--randomColor); width: 78%; height: 78%; margin: 11%; -webkit-clip-path: polygon(34% 0, 66% 0, 66% 34%, 100% 34%, 100% 66%, 66% 66%, 66% 100%, 34% 100%, 34% 66%, 0 66%, 0 34%, 34% 34%); clip-path: polygon(34% 0, 66% 0, 66% 34%, 100% 34%, 100% 66%, 66% 66%, 66% 100%, 34% 100%, 34% 66%, 0 66%, 0 34%, 34% 34%); /* Upright pluses twice as often as tilted crosses */ -webkit-transform: rotate(@pick(0deg, 0deg, 45deg)); transform: rotate(@pick(0deg, 0deg, 45deg)); -webkit-transition: ease 400ms; transition: ease 400ms; } /* A few stitches shrink into knots */ @random(0.15) { -webkit-clip-path: circle(18% at 50% 50%); clip-path: circle(18% at 50% 50%); } );",
+    "doodle": ":doodle { @grid: ${grid}; @size: ${width} ${height}; overflow:hidden; text-align:center; box-sizing:border-box } :container { background: var(--color0); overflow:hidden; }"
+  }
+}

--- a/artworks/weave.json
+++ b/artworks/weave.json
@@ -1,0 +1,31 @@
+{
+  "name": "Weave",
+  "slug": "weave",
+  "galleryOrder": 21,
+  "description": "Stripes alternate between warp and weft from cell to cell, basket-weaving the canvas with the occasional solid patch.",
+  "palette": ["#FFFFFF", "#3E8BFF", "#1B4075", "#3EECFF", "#FF3D8B", "#3FFFB2"],
+  "options": [
+    {
+      "id": "grid",
+      "displayName": "Columns and rows",
+      "type": "ButtonSelectGroup",
+      "default": "6x9",
+      "options": ["2x3", "4x6", "6x9", "8x12", "10x15"],
+      "replace": "${grid}"
+    },
+    {
+      "id": "frequency",
+      "displayName": "Frequency",
+      "type": "Slider",
+      "default": 1,
+      "min": 0.2,
+      "max": 1,
+      "step": 0.1,
+      "replace": "${shapeFrequency}"
+    }
+  ],
+  "code": {
+    "style": "/* Independent colors for stripes and solid patches */ --randomColor: @p(var(--color1), var(--color2), var(--color3), var(--color4), var(--color5)); --randomColor2: @p(var(--color1), var(--color2), var(--color3), var(--color4), var(--color5)); --rule: ( /*Frequency options of 0.2, 0.4, 0.6, 0.8, 1.0 */ @random(${shapeFrequency}) { background: repeating-linear-gradient(@pick(0deg, 90deg), var(--randomColor), var(--randomColor) 12.5%, var(--color0) 12.5%, var(--color0) 25%); } /* Occasional solid patch interrupts the weave */ @random(0.12) { background: var(--randomColor2); border-radius: @pick(0, 50%); -webkit-transition: ease 400ms; transition: ease 400ms; } );",
+    "doodle": ":doodle { @grid: ${grid}; @size: ${width} ${height}; overflow:hidden; text-align:center; box-sizing:border-box } :container { background: var(--color0); overflow:hidden; }"
+  }
+}

--- a/components/select-artwork-page/galleryThumbnails.ts
+++ b/components/select-artwork-page/galleryThumbnails.ts
@@ -73,4 +73,38 @@ export const galleryThumbnails: Record<string, ThumbnailConfig> = {
     palette: ['#FF3D8B', '#C9447A', '#A33261', '#232529'],
     options: { grid: '3x3', frequency: 0.75 },
   },
+  maze: {
+    palette: ['#E9F1FF', '#232529', '#3E8BFF', '#FF3D8B', '#3FFFB2', '#3EECFF'],
+    options: { grid: '7x7', frequency: 0.95, thickness: 9 },
+  },
+  pinwheel: {
+    palette: ['#232529', '#3E8BFF', '#3EECFF', '#FF3D8B', '#3FFFB2', '#F5DD32'],
+    options: { grid: '3x3', frequency: 0.9 },
+  },
+  orbit: {
+    options: { grid: '3x3', frequency: 0.8 },
+  },
+  confetti: {
+    options: { grid: '4x4', frequency: 0.95 },
+  },
+  foliage: {
+    palette: ['#ECFFEC', '#3FFFB2', '#3E8BFF', '#9EFFD8', '#FF3D8B', '#F5DD32'],
+    options: { grid: '4x4', frequency: 0.9 },
+  },
+  arco: {
+    options: { grid: '3x3', frequency: 0.9 },
+  },
+  metro: {
+    options: { grid: '6x6', frequency: 0.95 },
+  },
+  polka: {
+    options: { grid: '4x4', frequency: 0.85 },
+  },
+  stitch: {
+    palette: ['#9EFFD8', '#FF3D8B', '#3E8BFF', '#1B4075', '#232529', '#F5DD32'],
+    options: { grid: '4x4', frequency: 0.8 },
+  },
+  weave: {
+    options: { grid: '4x4', frequency: 0.75 },
+  },
 };


### PR DESCRIPTION
## Summary

Adds 10 new css-doodle artwork presets to the gallery (orders 12–21), each built around a different generative technique, plus tuned live-thumbnail configs in `galleryThumbnails.ts`. No code changes were needed beyond the thumbnail config — the gallery, editor, homepage section, and routes all pick the new presets up from the `artworks/` folder automatically.

| Artwork | Technique |
|---|---|
| **Maze** | 10 PRINT-style diagonal strokes with junction dots, plus a stroke-thickness slider |
| **Pinwheel** | Conic-gradient discs split into alternating quarter wedges, some with punched-out centers |
| **Orbit** | Rings on a dark field, each with a "moon" rotated to a random spot on its orbit |
| **Confetti** | Circles/triangles/squares/strips at random sizes, positions and rotations |
| **Foliage** | Gradient leaf shapes (two rounded opposite corners) with occasional berries and a shadow toggle |
| **Arco** | Concentric rainbow arches via double-position radial-gradient stops |
| **Metro** | Quarter-circle arcs centered on cell-edge midpoints so lines connect into a transit-map tangle, with station dots |
| **Polka** | Dots of random diameter with a hollow-rings toggle |
| **Stitch** | Embroidered plus signs and tilted crosses, with a few knots |
| **Weave** | Basket-weave stripes alternating warp/weft per cell, with solid patches |

One css-doodle quirk worth noting: `@p()` custom properties are re-rolled per `var()` occurrence, so a gradient that repeats the same var at two stops blends two different colors. Maze/Metro/Weave/Pinwheel lean into that for two-tone strokes; Arco avoids it with double-position stops (`var(--c) 0% 22%`) to keep its bands crisp.

## Testing

- `yarn build` passes; all 21 artwork routes prerender
- `yarn test:e2e` — all 12 existing Playwright smoke tests pass
- Verified with a Playwright script that every new design paints cells in both the editor (`/artwork/<slug>`) and the gallery thumbnail, and visually reviewed screenshots of all 10 editors, the polka hollow toggle, and the full gallery

https://claude.ai/code/session_01AVKd9YXE8FDo3oKp6HPV2o

---
_Generated by [Claude Code](https://claude.ai/code/session_01AVKd9YXE8FDo3oKp6HPV2o)_